### PR TITLE
Move lru_cache definitions to __init__

### DIFF
--- a/dissect/cim/index.py
+++ b/dissect/cim/index.py
@@ -15,6 +15,7 @@ from dissect.cim.exceptions import ReferenceNotFoundError
 class Index:
     def __init__(self, cim, fh, mapping):
         self.store = Store(cim, fh, mapping)
+
         self._lookup = lru_cache(1024)(self._lookup)
 
     def lookup(self, key):
@@ -88,13 +89,13 @@ class IndexPage:
         self.logical_num = logical_num
         self.page_num = page_num
 
-        self.key = lru_cache(256)(self.key)
-
         start = fh.tell()
         self.page = c_cim.index_page(fh)
         self.data = fh.read(INDEX_PAGE_SIZE - (fh.tell() - start))
 
         self.count = self.page.record_count
+
+        self.key = lru_cache(256)(self.key)
 
     def _string_part(self, idx):
         offset = self.page.string_table[idx]

--- a/dissect/cim/mappings.py
+++ b/dissect/cim/mappings.py
@@ -11,12 +11,12 @@ class Mapping:
         self.cim = cim
         self.mapping = cim.map_type(fh)
 
-        self.get_entry = lru_cache(256)(self.get_entry)
-
         if self.mapping.signature != 0xABCD:
             raise Error("Invalid mapping file!")
 
         self._reverse_map = {}
+
+        self.get_entry = lru_cache(256)(self.get_entry)
 
     def __getitem__(self, k):
         if not isinstance(k, int):


### PR DESCRIPTION
Using the lru_cache decorators on class methods, the ones that have a reference to `self`,
will also cache self. So we move it to the __init__ of the class
    
(DIS-2913)